### PR TITLE
test: ツイートテキスト抽出機能のユニットテスト追加

### DIFF
--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -62,11 +62,89 @@ def apigw_event():
     }
 
 
-def test_lambda_handler(apigw_event):
+@pytest.fixture()
+def tweet_event():
+    """ Generates Tweet Event with HTML content """
+    
+    return {
+        "body": '<blockquote class="twitter-tweet">\n  <p lang="en" dir="ltr">テストツイート本文\n#NEEDY_pic https://t.co/ItIsVAWSlQ</p>\n  &mdash; テストユーザー (@test_user)\n  <a href="https://twitter.com/test_user/status/123456789">Jan 24, 2025</a>\n</blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n',
+        "resource": "/hello",
+        "path": "/hello/",
+        "httpMethod": "POST",
+        "isBase64Encoded": False,
+        "queryStringParameters": None,
+        "pathParameters": None,
+        "stageVariables": None,
+        "headers": {
+            "Content-type": "application/json",
+            "User-Agent": "Amazon CloudFront",
+            "Host": "example.com"
+        },
+        "requestContext": {
+            "resourceId": "shd55o",
+            "resourcePath": "/hello",
+            "httpMethod": "POST",
+            "path": "/Prod/hello/",
+            "protocol": "HTTP/1.1",
+            "stage": "Prod"
+        }
+    }
 
+
+@pytest.fixture()
+def array_tweet_event():
+    """ Generates Array of Tweet Events """
+    
+    return [{
+        "body": '<blockquote class="twitter-tweet">\n  <p lang="en" dir="ltr">配列形式のテストツイート\n#NEEDY_pic https://t.co/ItIsVAWSlQ</p>\n  &mdash; テストユーザー (@test_user)\n  <a href="https://twitter.com/test_user/status/123456789">Jan 24, 2025</a>\n</blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n',
+        "resource": "/hello",
+        "path": "/hello/",
+        "httpMethod": "POST",
+        "isBase64Encoded": False,
+        "queryStringParameters": None,
+        "pathParameters": None,
+        "stageVariables": None,
+        "headers": {
+            "Content-type": "application/json",
+            "User-Agent": "Amazon CloudFront",
+            "Host": "example.com"
+        },
+        "requestContext": {
+            "resourceId": "shd55o",
+            "resourcePath": "/hello",
+            "httpMethod": "POST",
+            "path": "/Prod/hello/",
+            "protocol": "HTTP/1.1",
+            "stage": "Prod"
+        }
+    }]
+
+
+def test_lambda_handler(apigw_event):
+    """ 基本的なレスポンスのテスト """
     ret = app.lambda_handler(apigw_event, "")
     data = json.loads(ret["body"])
 
     assert ret["statusCode"] == 200
     assert "message" in ret["body"]
     assert data["message"] == "hello world"
+
+
+def test_tweet_text_extraction(tweet_event):
+    """ ツイートテキスト抽出機能のテスト """
+    ret = app.lambda_handler(tweet_event, "")
+    data = json.loads(ret["body"])
+
+    assert ret["statusCode"] == 200
+    assert "tweet_text" in data
+    assert data["tweet_text"] == "テストツイート本文\n#NEEDY_pic https://t.co/ItIsVAWSlQ"
+
+
+def test_array_event_handling(array_tweet_event):
+    """ 配列形式のイベント処理のテスト """
+    ret = app.lambda_handler(array_tweet_event, "")
+    data = json.loads(ret["body"])
+
+    assert ret["statusCode"] == 200
+    assert "tweet_text" in data
+    assert data["tweet_text"] == "配列形式のテストツイート\n#NEEDY_pic https://t.co/ItIsVAWSlQ"


### PR DESCRIPTION
## 変更内容

### 主な変更点
- ツイートテキスト抽出機能のユニットテストを追加
- 配列形式のイベント処理のテストを追加

### 技術的な詳細
- `tweet_event` フィクスチャの追加: HTMLコンテンツを含むツイートイベントを生成
- `array_tweet_event` フィクスチャの追加: 配列形式のツイートイベントを生成
- `test_tweet_text_extraction` テスト関数の追加: ツイートテキスト抽出機能のテスト
- `test_array_event_handling` テスト関数の追加: 配列形式のイベント処理のテスト

## テスト結果
- すべてのユニットテストが正常に実行されることを確認済み
- `PYTHONPATH=. python -m pytest tests/unit/test_handler.py -v` コマンドで3つのテストがすべて成功

## 今後の展開
- エラーケースのテストの追加
- 様々なツイート形式に対応するテストの追加
- 統合テストの実装
